### PR TITLE
Update pom.xml to add parameters flag to maven compiler plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -566,6 +566,7 @@
                     <configuration>
                         <source>${maven.compiler.source}</source>
                         <target>${maven.compiler.target}</target>
+                        <parameters>true</parameters>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
Update pom.xml to add parameters flag to maven compiler plugin section to address issue seen downstream in IZG Hub.