### PR TITLE
fix: Manually set parent in validation pom

### DIFF
--- a/validation/pom.xml
+++ b/validation/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>gov.cdc.izgw</groupId>
         <artifactId>izgw-bom</artifactId>
-        <version>1.7.0</version>
+        <version>1.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Release process didn't set properly and so nightly dependency check failed.