### PR TITLE
fix(ci): temp disable OSS Index while Sonatype free credits are exhausted

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -110,8 +110,7 @@ jobs:
             out: "dependency-check-report"
             args: >
               --suppression /github/workspace/dependency-suppression.xml
-              --ossIndexUsername ${{ secrets.OSS_INDEX_USERNAME }}
-              --ossIndexPassword ${{ secrets.OSS_INDEX_PASSWORD }}
+              --disableOssIndex
               --failOnCVSS 7
               --format JSON
               --nvdApiKey ${{ secrets.NVDAPIKEY }}


### PR DESCRIPTION
## Problem

Sonatype OSS Index free credits are exhausted, causing the CVE scan step to fail and blocking all CI runs.

## Fix

Replaces `--ossIndexUsername` / `--ossIndexPassword` with `--disableOssIndex` so the scan runs on NVD alone.

## Reverting when credits are restored

Remove `--disableOssIndex` and restore the two `--ossIndex*` args (see git history for exact values).

## Notes

- Temporary fix targeting the current inline CVE scan step on `develop`.
- The longer-term solution (migrating to the shared `cve-scan` composite action from `izg-dependency-scripts`, which has proper `disable-oss-index` support) is tracked in branch `IGDD-2563_migrate_cve_scan_action`.