### PR TITLE
ci: upgrade GitHub Actions to Node.js 24 and add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+    labels:
+      - 'dependencies'
+      - 'github-actions'
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          ['version-update:semver-patch', 'version-update:semver-minor']

--- a/.github/workflows/_release_common.yml
+++ b/.github/workflows/_release_common.yml
@@ -25,12 +25,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Full history for release notes generation
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: "21"
           distribution: "temurin"
@@ -38,7 +38,7 @@ jobs:
           server-id: github
 
       - name: Set up Maven
-        uses: stCarolas/setup-maven@v5
+        uses: stCarolas/setup-maven@v5.1
         with:
           maven-version: 3.9.14
 
@@ -424,7 +424,7 @@ jobs:
           echo "GitHub Release body created"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ inputs.release-version }}
           name: IZ Gateway - BOM - v${{ inputs.release-version }}

--- a/.github/workflows/dependency-updates.yml
+++ b/.github/workflows/dependency-updates.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: "21"
           distribution: "temurin"
@@ -26,7 +26,7 @@ jobs:
           server-id: github
 
       - name: Set up Maven 3.9.14
-        uses: stCarolas/setup-maven@v5
+        uses: stCarolas/setup-maven@v5.1
         with:
           maven-version: 3.9.14
 
@@ -126,7 +126,7 @@ jobs:
         run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
       - name: Cache Dependency-Check NVD data (pre-update)
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/dependency-check-data
           key: dependency-check-nvd-${{ runner.os }}-${{ steps.date-pre.outputs.date }}
@@ -157,7 +157,7 @@ jobs:
 
       - name: Upload pre-update CVE report artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dependency-check-report-pre-update
           path: dependency-check-report-pre/
@@ -372,7 +372,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Dependency-Check NVD data (post-update)
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/dependency-check-data
           key: dependency-check-nvd-${{ runner.os }}-${{ steps.date-pre.outputs.date }}
@@ -403,7 +403,7 @@ jobs:
 
       - name: Upload post-update CVE report artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dependency-check-report-post-update
           path: dependency-check-report-post/
@@ -445,7 +445,7 @@ jobs:
 
       - name: Upload debug artifacts on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: debug-logs
           if-no-files-found: ignore
@@ -508,7 +508,7 @@ jobs:
 
       - name: Send email notification
         if: env.HAS_CHANGES == 'true' && env.PR_URL != ''
-        uses: dawidd6/action-send-mail@v3
+        uses: dawidd6/action-send-mail@v17
         with:
           server_address: email-smtp.us-east-1.amazonaws.com
           server_port: 465

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,10 +24,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: "21"
           distribution: "temurin"
@@ -35,7 +35,7 @@ jobs:
           server-id: github
 
       - name: Set up Maven 3.9.14
-        uses: stCarolas/setup-maven@v5
+        uses: stCarolas/setup-maven@v5.1
         with:
           maven-version: 3.9.14
 
@@ -89,7 +89,7 @@ jobs:
         run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
       - name: Cache Dependency-Check NVD data
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/dependency-check-data
           key: dependency-check-nvd-${{ runner.os }}-${{ steps.date.outputs.date }}
@@ -121,7 +121,7 @@ jobs:
 
       - name: Upload CVE report artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dependency-check-report
           path: dependency-check-report/


### PR DESCRIPTION
- Updated all workflow actions to their latest stable Node.js 24 compatible versions (node20 deprecated, forced to node24 June 2 2026)
- Added .github/dependabot.yml to keep action versions up-to-date automatically going forward (weekly, major versions only)